### PR TITLE
Abstract gem version into version file

### DIFF
--- a/acts_as_boolean.gemspec
+++ b/acts_as_boolean.gemspec
@@ -1,6 +1,8 @@
+require_relative 'version'
+
 Gem::Specification.new do |s|
   s.name        = 'acts_as_boolean'
-  s.version     = '0.1.0'
+  s.version     = ActsAsBoolean::VERSION
   s.platform    = Gem::Platform::RUBY
   s.author      = 'Tim Harvey'
   s.email       = 'tharvey@squaremouth.com'

--- a/version.rb
+++ b/version.rb
@@ -1,0 +1,3 @@
+module ActsAsBoolean
+  VERSION = "0.1.0"
+end


### PR DESCRIPTION
In order to prepare for the use of github packages and actions for
version checking, this pull request removes the setting of the gem
version in the gemspec and adds the version to a version file.